### PR TITLE
Removed redundant IO_HEADERS redefinition

### DIFF
--- a/BasicCommunitiesDetection/CMakeLists.txt
+++ b/BasicCommunitiesDetection/CMakeLists.txt
@@ -1,8 +1,5 @@
 # grappolo 
 
-set( IO_HEADERS
-  ${CMAKE_SOURCE_DIR}/DefineStructure
-)
 
 set( COFOLDER_SRC
      ${CMAKE_SOURCE_DIR}/${COFOLDER}/parallelLouvainMethodApprox-2.cpp

--- a/Coloring/CMakeLists.txt
+++ b/Coloring/CMakeLists.txt
@@ -1,8 +1,5 @@
 # grappolo 
 
-set( IO_HEADERS
-  ${CMAKE_SOURCE_DIR}/DefineStructure
-)
 
 set( CLFOLDER_SRC
      ${CMAKE_SOURCE_DIR}/${CLFOLDER}/coloringDistanceOne.cpp

--- a/FullSyncOptimization/CMakeLists.txt
+++ b/FullSyncOptimization/CMakeLists.txt
@@ -1,8 +1,5 @@
 # grappolo 
 
-set( IO_HEADERS
-  ${CMAKE_SOURCE_DIR}/DefineStructure
-)
 
 set( FSFOLDER_SRC
      ${CMAKE_SOURCE_DIR}/${FSFOLDER}/fullSyncUtility.cpp

--- a/InputsOutput/CMakeLists.txt
+++ b/InputsOutput/CMakeLists.txt
@@ -1,8 +1,5 @@
 # grappolo 
 
-set( IO_HEADERS
-  ${CMAKE_SOURCE_DIR}/DefineStructure
-)
 
 set( IOFOLDER_SRC
   ${CMAKE_SOURCE_DIR}/${IOFOLDER}/loadBinary.cpp

--- a/Utility/CMakeLists.txt
+++ b/Utility/CMakeLists.txt
@@ -1,8 +1,5 @@
 # grappolo 
 
-set( IO_HEADERS
-  ${CMAKE_SOURCE_DIR}/DefineStructure
-)
 
 set( UTFOLDER_SRC
      ${CMAKE_SOURCE_DIR}/${UTFOLDER}/buildNextPhase.cpp


### PR DESCRIPTION
IO_HEADERS is already defined in the parent CMakeLists.txt file, removing this allows for these libraries to be used in projects located outside its parent directory.